### PR TITLE
:bug: Fix duplicate res.send calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,7 +251,8 @@ apiRouter.post("/menu", async function (req, res) {
 
   // 최근 3개월 이내의 날짜가 아닌경우 알려주지 않음
   if (isBeforeOrAfterMonths(requestDate, 3)) {
-    responseSimpleText(res, "최근 3개월 이내의 날짜만 조회 가능합니다.");
+    console.log("최근 3개월 이내의 날짜만 조회 가능합니다.");
+    return responseSimpleText(res, "최근 3개월 이내의 날짜만 조회 가능합니다.");
   }
 
   // /menu/Eunpyeong/year_2022/month_03
@@ -265,7 +266,7 @@ apiRouter.post("/menu", async function (req, res) {
   let menuJson = {};
   if (!menu_doc.exists) {
     console.log("No such document!");
-    responseSimpleText(res, noMenuMsg);
+    return responseSimpleText(res, noMenuMsg);
   } else {
     // console.log("Document data:", menu_doc.data());
     menuJson = menu_doc.data();
@@ -294,7 +295,7 @@ apiRouter.post("/menu", async function (req, res) {
   }
 
   if (!selectedBreakfastMenu && !selectedLunchMenu && !selectedDinnerMenu) {
-    responseSimpleText(res, noMenuMsg);
+    return responseSimpleText(res, noMenuMsg);
   }
 
   if (!selectedBreakfastMenu) {
@@ -309,7 +310,7 @@ apiRouter.post("/menu", async function (req, res) {
     selectedDinnerMenu = noMenuMsg;
   }
 
-  responseSimpleText(
+  return responseSimpleText(
     res,
     `<${selectedDate}> 식단 정보 \n\n[아침]\n${selectedBreakfastMenu}\n\n[점심]\n${selectedLunchMenu}\n\n[저녁]\n${selectedDinnerMenu}`,
     main_menu_block_id,


### PR DESCRIPTION
Addressed the issue of duplicate execution in the Node.js application by adding return statements. The problem caused redundant or conflicting code paths to be executed, leading to unexpected behavior. The following changes were made to resolve the problem:

- Identified the areas of the code where duplicate execution occurred due to missing return statements.
- Added appropriate return statements to terminate the function execution and prevent subsequent code from being executed.
- Ensured that the response is sent only once by controlling the execution flow using return statements after sending the response with res.send.

By adding return statements at the appropriate locations, the issue of duplicate execution was resolved. This ensures that the code path is executed only once and mitigates any undesirable side effects.